### PR TITLE
Fix redirect with Strawpoll

### DIFF
--- a/src/Plugins/MediaEmbed/Configurator/sites/strawpoll.xml
+++ b/src/Plugins/MediaEmbed/Configurator/sites/strawpoll.xml
@@ -3,5 +3,5 @@
 
 	<host>strawpoll.me</host>
 	<extract>!strawpoll\.me/(?'id'\d+)!</extract>
-	<iframe width="600" height="310" src="//strawpoll.me/embed_1/{@id}" scrolling=""/>
+	<iframe width="600" height="310" src="//www.strawpoll.me/embed_1/{@id}" scrolling=""/>
 </site>


### PR DESCRIPTION
Every links `//strawpoll.me/embed_1/{@id}` are redirected to `http://www.strawpoll.me/embed_1/{@id}` so the content doesn't work on HTTPS.
Add a `www.` before `strawpoll.me` fix the problem.