### PR TITLE
Censor: Fix "curses" passing the censor filter.

### DIFF
--- a/src/Plugins/Censor/Helper.php
+++ b/src/Plugins/Censor/Helper.php
@@ -76,7 +76,7 @@ class Helper
 		$regexp = $delim
 		        . '(?<!&#)(?<!&)'
 		        . substr($this->regexp, 1, $pos - 1)
-		        . '(?=[^<">]*(?=<|$' . $attributesExpr . '))'
+		        . '(?=[^<>]*(?=<|$' . $attributesExpr . '))'
 		        . substr($this->regexp, $pos);
 
 		return preg_replace_callback(

--- a/tests/Plugins/Censor/HelperTest.php
+++ b/tests/Plugins/Censor/HelperTest.php
@@ -143,6 +143,16 @@ class HelperTest extends Test
 		);
 	}
 
+	public function testCensorHtmlQuotes()
+	{
+		$this->configurator->Censor->add('pineapple') ;
+
+		$this->assertSame(
+			'You dirty "****"',
+			$this->configurator->Censor->getHelper()->censorHtml('You dirty "pineapple"')
+		);
+	}
+
 	/**
 	* @testdox censorText() censors plain text
 	*/


### PR DESCRIPTION
Hey JoshyPHP, I've noticed a lot of users getting past the censored word filter on my phpBB forum by putting it in quotes. 😔

Eg. `"curses" curses` → `"curses" ****`

This doesn't seem required to avoid censorAttributes, as far as I can see.

Eg. `<p class=curses>curses "curses"</p>` → `<p class=curses>**** "curses"</p>`

Reimplementing another way is fine.