### PR TITLE
Add notAfter and notBefore for emoji aliases

### DIFF
--- a/src/Plugins/Emoji/Parser.js
+++ b/src/Plugins/Emoji/Parser.js
@@ -79,6 +79,11 @@ function parseCustomAliases(text)
 	while (m = config.customRegexp.exec(text))
 	{
 		var alias = m[0], tagPos = m['index'];
+		if (HINT.EMOJI_NOT_AFTER && config.notAfter && tagPos && config.notAfter.test(text[tagPos - 1]))
+		{
+			continue;
+		}
+		
 		if (registeredVars['Emoji.aliases'][alias])
 		{
 			var hex = getHexSequence(registeredVars['Emoji.aliases'][alias]);


### PR DESCRIPTION
I tried to replicate the behaviour of notAfter and notBefore from the emoticons plugin for emoji aliases. This helps a lot in our forum to prevent false positives of emoticon aliases like `:P`, `:D`, `:)` etc in regular text and urls. Not sure if the regexps are fully optimized, I noticed emoticons use S flag at the end.