### PR TITLE
Amend document typos

### DIFF
--- a/docs/Plugins/Autovideo/Synopsis.md
+++ b/docs/Plugins/Autovideo/Synopsis.md
@@ -1,4 +1,4 @@
-This plugin converts plain-text video URLs into playable videos. Only URLs starting with `http://` or `https://` and ending with `.mp4, `.ogg` or `.webm` are converted.
+This plugin converts plain-text video URLs into playable videos. Only URLs starting with `http://` or `https://` and ending with `.mp4`, `.ogg` or `.webm` are converted.
 
 ## Examples
 

--- a/docs/Plugins/Keywords/Map.md
+++ b/docs/Plugins/Keywords/Map.md
@@ -1,6 +1,6 @@
 <h2>How to map keywords to IDs</h2>
 
-Sometimes, keywords are not the best way to identify a resource. For instance, in a tabletop games forum you may want to map the name of spell cards to the name of its image file. This example is inspired by the Mage Wars forum [Arcane Wonders](https://forum.arcanewonders.com/index.php?topic=13249.msg25802).
+Sometimes, keywords are not the best way to identify a resource. For instance, in a tabletop games forum you may want to map the name of spell cards to the name of its image file. This example is inspired by the Mage Wars forum [Arcane Wonders](http://forum.arcanewonders.com/index.php?topic=13249.msg25802).
 
 In the following example, we use the Keywords plugin to capture card names used in normal text. We use one of the [built-in filter](https://github.com/s9e/TextFormatter/blob/master/docs/BuiltInFilters.md) `#hashmap` on the `value` attribute to map the name of the card to its ID. Additionally, we see how additional filters can be used to transform attributes' values. In this instance, we use `strtolower()` to normalize the keyword value to lowercase.
 

--- a/docs/Plugins/Litedown/Synopsis.md
+++ b/docs/Plugins/Litedown/Synopsis.md
@@ -1,6 +1,6 @@
 This plugin implements a Markdown-like syntax, inspired by modern flavors of Markdown.
 
-A more detailed description of the syntax in available in [Syntax](Syntax.md).
+A more detailed description of the syntax is available in [Syntax](Syntax.md).
 
 ## Example
 


### PR DESCRIPTION
The URL to the Arcane Wonders forum no longer works with `https`, just with `http` at the moment.