### PR TITLE
Autolink trimUrl underscore fix

### DIFF
--- a/src/Plugins/Autolink/Parser.js
+++ b/src/Plugins/Autolink/Parser.js
@@ -47,6 +47,7 @@ function linkifyUrl(tagPos, url)
 * We remove most ASCII non-letters from the end of the string.
 * Exceptions:
 *  - dashes (some YouTube URLs end with a dash due to the video ID)
+*  - underscores
 *  - equal signs (because of "foo?bar="),
 *  - trailing slashes,
 *  - closing parentheses are balanced separately.

--- a/src/Plugins/Autolink/Parser.js
+++ b/src/Plugins/Autolink/Parser.js
@@ -56,5 +56,5 @@ function linkifyUrl(tagPos, url)
 */
 function trimUrl(url)
 {
-	return url.replace(/(?![-=\/)])[\s!-.:-@[-`{-~]+$/, '');
+	return url.replace(/(?![-_=\/)])[\s!-.:-@[-`{-~]+$/, '');
 }

--- a/src/Plugins/Autolink/Parser.php
+++ b/src/Plugins/Autolink/Parser.php
@@ -67,6 +67,7 @@ class Parser extends ParserBase
 	* We remove most ASCII non-letters and Unicode punctuation from the end of the string.
 	* Exceptions:
 	*  - dashes (some YouTube URLs end with a dash due to the video ID)
+	*  - underscores
 	*  - equal signs (because of "foo?bar="),
 	*  - trailing slashes,
 	*  - closing parentheses are balanced separately.
@@ -76,6 +77,6 @@ class Parser extends ParserBase
 	*/
 	protected function trimUrl($url)
 	{
-		return preg_replace('#(?![-=/)])[\\s!-.:-@[-`{-~\\pP]+$#Du', '', $url);
+		return preg_replace('#(?![-_=/)])[\\s!-.:-@[-`{-~]+$#Du', '', $url);
 	}
 }


### PR DESCRIPTION
### Fixes Bug:  

the url: https://www.example.com/test_ would be trimmed to https://www.example.com/test.
this commit prevents it. 
I also removed the additional punctuation match \p{P} in the php file - don't think it's needed now, but let me know if it is.