### PR TITLE
Use correct parameter type in setParameters docblock

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -131,7 +131,7 @@ abstract class Renderer
 	/**
 	* Set the values of several parameters from the stylesheet
 	*
-	* @param  string $params Associative array of [parameter name => parameter value]
+	* @param  array $params Associative array of [parameter name => parameter value]
 	* @return void
 	*/
 	public function setParameters(array $params)


### PR DESCRIPTION
The parameter type in the docblock of setParameters() is defined as string,
while the actual method declaration quite clearly enforces and expects an array.