### PR TITLE
Use callable as parameter type in replaceAttributes docblock

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -105,7 +105,7 @@ abstract class Utils
 	*
 	* @param  string   $xml      Original XML
 	* @param  string   $tagName  Target tag's name
-	* @param  callback $callback Callback used to process attributes. Receives the old attributes
+	* @param  callable $callback Callback used to process attributes. Receives the old attributes
 	*                            as an array, should return the new attributes as an array
 	* @return string             Modified XML
 	*/


### PR DESCRIPTION
The currently used callback is interpreted as s9e\TextFormatter\callback
instead of callable.