### PR TITLE
Allow trailing plus sign in Autolink

### DIFF
--- a/src/Plugins/Autolink/Parser.js
+++ b/src/Plugins/Autolink/Parser.js
@@ -42,6 +42,7 @@ function linkifyUrl(tagPos, url)
 * Exceptions:
 *  - dashes and underscores, (base64 IDs could end with one)
 *  - equal signs, (because of "foo?bar=")
+*  - plus signs, (used by some file share services to force download)
 *  - trailing slashes,
 *  - closing parentheses. (they are balanced separately)
 *
@@ -50,5 +51,5 @@ function linkifyUrl(tagPos, url)
 */
 function trimUrl(url)
 {
-	return url.replace(/(?:(?![-=)\/_])[\s!-.:-@[-`{-~])+$/, '');
+	return url.replace(/(?:(?![-=+)\/_])[\s!-.:-@[-`{-~])+$/, '');
 }

--- a/src/Plugins/Autolink/Parser.php
+++ b/src/Plugins/Autolink/Parser.php
@@ -62,6 +62,7 @@ class Parser extends ParserBase
 	* Exceptions:
 	*  - dashes and underscores, (base64 IDs could end with one)
 	*  - equal signs, (because of "foo?bar=")
+    *  - plus signs, (used by some file share services to force download)
 	*  - trailing slashes,
 	*  - closing parentheses. (they are balanced separately)
 	*
@@ -70,6 +71,6 @@ class Parser extends ParserBase
 	*/
 	protected function trimUrl($url)
 	{
-		return preg_replace('#(?:(?![-=)/_])[\\s!-.:-@[-`{-~\\pP])+$#Du', '', $url);
+		return preg_replace('#(?:(?![-=+)/_])[\\s!-.:-@[-`{-~\\pP])+$#Du', '', $url);
 	}
 }

--- a/tests/Plugins/Autolink/ParserTest.php
+++ b/tests/Plugins/Autolink/ParserTest.php
@@ -64,6 +64,10 @@ class ParserTest extends Test
 				'Go to http://www.example.com/?foo= for more info',
 				'<r>Go to <URL url="http://www.example.com/?foo=">http://www.example.com/?foo=</URL> for more info</r>'
 			],
+            [
+                'Download http://www.example.com/foo+ on your computer',
+                '<r>Download <URL url="http://www.example.com/foo+">http://www.example.com/foo+</URL> on your computer</r>'
+            ],
 			[
 				'Mars (http://en.wikipedia.org/wiki/Mars_(planet)) is the fourth planet from the Sun',
 				'<r>Mars (<URL url="http://en.wikipedia.org/wiki/Mars_%28planet%29">http://en.wikipedia.org/wiki/Mars_(planet)</URL>) is the fourth planet from the Sun</r>'


### PR DESCRIPTION
This was reported by a client using [CleanShot X](https://cleanshot.com/) for Mac.

Their share links look like https://cln.sh/abcDEF (not an actual link) where https://cln.sh/abcDEF+ causes a direct download instead of a preview.

We can actually see in the paragraph above that GitHub itself also auto-links such an URL.