### PR TITLE
refactor: Remove redundant use statement

### DIFF
--- a/src/Configurator/JavaScript/Encoder.php
+++ b/src/Configurator/JavaScript/Encoder.php
@@ -11,7 +11,6 @@ use RuntimeException;
 use s9e\TextFormatter\Configurator\Items\Regexp;
 use s9e\TextFormatter\Configurator\JavaScript\Code;
 use s9e\TextFormatter\Configurator\JavaScript\Dictionary;
-use s9e\TextFormatter\Configurator\JavaScript\Encoder;
 
 class Encoder
 {


### PR DESCRIPTION
This removes the warning "Cannot redeclare class/interface 'Encoder'" in the VS Code editor.

![sshot-12](https://github.com/user-attachments/assets/af2d6996-471e-4673-9f0b-cdcc3810ae87)
